### PR TITLE
Workflow create Buster docker image

### DIFF
--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -69,9 +69,26 @@ jobs:
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: "VERSION=${{ github.ref_name }}"
+          build-args: "VERSION=${{ env.GITHUB_BRANCH }}"
           tags: |
             "${{ env.JEEDOM_TAGS }}"
+
+      - name: Build and push Jeedom on Debian:Buster
+        # https://github.com/marketplace/actions/build-and-push-docker-images
+        uses: docker/build-push-action@v3
+        # continue-on-error: true
+        with:
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64 # ,linux/arm/v7
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          build-args: |
+            "VERSION=${{ env.GITHUB_BRANCH }}"
+            "DEBIAN=buster"
+          tags: |
+            "${{ secrets.DOCKER_HUB_USERNAME }}/jeedom:${{ env.JEEDOM_SHORT_VERSION}}-buster"
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-FROM debian:11
+ARG DEBIAN=bullseye
+FROM debian:${DEBIAN}
+ARG DEBIAN
 
-MAINTAINER info@jeedom.com
-
+# ARG to build Docker images ... ENV to run Docker container
 ARG WEBSERVER_HOME=/var/www/html
 ENV WEBSERVER_HOME=${WEBSERVER_HOME}
 ARG VERSION=V4-stable
 ENV VERSION=${VERSION}
+
+# labels follows opencontainers convention
+LABEL org.opencontainers.image.title='Jeedom'
+LABEL org.opencontainers.image.authors='info@jeedom.com'
+LABEL org.opencontainers.image.url='https://www.jeedom.com/'
+LABEL org.opencontainers.image.documentation='https://doc.jeedom.com/'
+LABEL org.opencontainers.image.source='https://github.com/jeedom/core'
+LABEL org.opencontainers.image.vendor='Jeedom SAS'
+LABEL org.opencontainers.image.licenses='GNU GENERAL PUBLIC LICENSE'
+LABEL org.opencontainers.image.version='${VERSION}-${DEBIAN}'
+LABEL org.opencontainers.image.description='Software for home automation'
 
 WORKDIR ${WEBSERVER_HOME}
 VOLUME ${WEBSERVER_HOME}

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -10,9 +10,9 @@ JAUNE="\\033[1;33m"
 CYAN="\\033[1;36m"
   
 service_mariadb(){
-  service $1 mariadb > /dev/null 2>&1
+  service mysql $1
   if [ $? -ne 0 ]; then
-    service $1 mysql > /dev/null 2>&1
+    service mariadb $1
     if [ $? -ne 0 ]; then
       echo "${ROUGE}Cannot start mariadb - Cancelling${NORMAL}"
       exit 1

--- a/install/OS_specific/Docker/init.sh
+++ b/install/OS_specific/Docker/init.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
+VERT="\\033[1;32m"
+NORMAL="\\033[0;39m"
+ROUGE="\\033[1;31m"
+ROSE="\\033[1;35m"
+BLEU="\\033[1;34m"
+BLANC="\\033[0;02m"
+BLANCLAIR="\\033[1;08m"
+JAUNE="\\033[1;33m"
+CYAN="\\033[1;36m"
+  
+service_mariadb(){
+  service $1 mariadb > /dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    service $1 mysql > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      echo "${ROUGE}Cannot start mariadb - Cancelling${NORMAL}"
+      exit 1
+    fi
+  fi
+  return 0
+}
+
 echo 'Start init'
 
 # $WEBSERVER_HOME and $VERSION env variables comes from Dockerfile
@@ -16,7 +38,7 @@ else
 	if [ $(which mysqld | wc -l) -ne 0 ]; then
 		chown -R mysql:mysql /var/lib/mysql
 		mysql_install_db --user=mysql --basedir=/usr/ --ldata=/var/lib/mysql/
-		service mariadb restart
+		service_mariadb restart
 		MYSQL_JEEDOM_PASSWD=$(cat /dev/urandom | tr -cd 'a-f0-9' | head -c 15)
 		echo "DROP USER 'jeedom'@'localhost';" | mysql > /dev/null 2>&1
 		echo  "CREATE USER 'jeedom'@'localhost' IDENTIFIED BY '${MYSQL_JEEDOM_PASSWD}';" | mysql
@@ -40,10 +62,10 @@ service atd restart
 if [ $(which mysqld | wc -l) -ne 0 ]; then
 	echo 'Starting mariadb'
 	chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
-	service mariadb restart
+	service_mariadb restart
 	if [ $? -ne 0 ]; then
 		 rm /var/lib/mysql/ib_logfile*
-		 service mariadb restart
+		 service_mariadb restart
 	fi
 fi
 

--- a/install/OS_specific/Docker/init_workflow.sh
+++ b/install/OS_specific/Docker/init_workflow.sh
@@ -6,10 +6,13 @@ JEEDOM_SHORT_VERSION="$(echo "$JEEDOM_VERSION" | awk -F. '{print $1"."$2}')"
 
 if [[ "${GITHUB_REF_NAME}" == "V4-Stable" ]]; then
   JEEDOM_TAGS="${DOCKER_HUB_USERNAME}/jeedom:latest,${DOCKER_HUB_USERNAME}/jeedom:$JEEDOM_SHORT_VERSION";
+  GITHUB_BRANCH=${GITHUB_REF_NAME};
 elif [[ "${GITHUB_REF_NAME}" == "beta" ]]; then
   JEEDOM_TAGS="${DOCKER_HUB_USERNAME}/jeedom:beta,${DOCKER_HUB_USERNAME}/jeedom:$JEEDOM_SHORT_VERSION";
+  GITHUB_BRANCH=${GITHUB_REF_NAME};
 else
   JEEDOM_TAGS="${DOCKER_HUB_USERNAME}/jeedom:$JEEDOM_SHORT_VERSION";
+  GITHUB_BRANCH=alpha;
 fi
 
 # GITHUB_ENV is the environment variables filename
@@ -17,6 +20,7 @@ fi
 echo "JEEDOM_VERSION=$JEEDOM_VERSION" >> $GITHUB_ENV
 echo "JEEDOM_SHORT_VERSION=$JEEDOM_SHORT_VERSION" >> $GITHUB_ENV
 echo "JEEDOM_TAGS=$JEEDOM_TAGS" >> $GITHUB_ENV
+echo "GITHUB_BRANCH=$GITHUB_BRANCH" >> $GITHUB_ENV
 
 # GITHUB_STEP_SUMMARY is the workflow summary
 # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary


### PR DESCRIPTION
## Proposed change

Add another Docker image based on Debian:Buster for some specific cases (synology) having some incompatibility with Bullseye.
Also a fix on init.sh with the database service name (mysql or mariadb)

## Type of change

- [ ] 3rd party lib update
- [x] Bugfix (non breaking change)
- [ ] Core new feature
- [ ] UI new functionnality
- [ ] Code quality improvements
- [ ] Core documentation
- [x] Docker and Github action new feature

## Test check

Build and test ok with my repo ( [Actions](https://github.com/pifou25/jeedom-core/actions) ) and the related docker image pifou25/jeedom:4.4-buster you may check this image:

`docker run -d -p 80:80 --rm --name jeedom pifou25/jeedom:4.4-buster`

## Documentation

[beta-testing](https://doc.jeedom.com/en_US/beta/)
[contribute](https://doc.jeedom.com/en_US/contribute/)
[community](https://community.jeedom.com/)
[plugins](https://doc.jeedom.com/en_US/dev/)

